### PR TITLE
Allow direct access to raw data

### DIFF
--- a/c/include/katherine/acquisition.h
+++ b/c/include/katherine/acquisition.h
@@ -57,6 +57,7 @@ typedef struct katherine_acquisition_handlers {
     void (*pixels_received)(void *, const void *, size_t);
     void (*frame_started)(void *, int);
     void (*frame_ended)(void *, int, bool, const katherine_frame_info_t *);
+    void (*data_received)(void *, const char *, size_t);
 } katherine_acquisition_handlers_t;
 
 typedef enum katherine_readout_type {
@@ -84,6 +85,7 @@ typedef struct katherine_acquisition {
     char *md_buffer;
     size_t md_buffer_size;
 
+    bool decode_data;
     char *pixel_buffer;
     size_t pixel_buffer_size;
     size_t pixel_buffer_valid;
@@ -112,7 +114,7 @@ KATHERINE_EXPORTED void
 katherine_acquisition_fini(katherine_acquisition_t *acq);
 
 KATHERINE_EXPORTED int
-katherine_acquisition_begin(katherine_acquisition_t *acq, const katherine_config_t *config, char readout_mode, katherine_acquisition_mode_t acq_mode, bool fast_vco_enabled);
+katherine_acquisition_begin(katherine_acquisition_t *acq, const katherine_config_t *config, char readout_mode, katherine_acquisition_mode_t acq_mode, bool fast_vco_enabled, bool decode_data);
 
 KATHERINE_EXPORTED int
 katherine_acquisition_abort(katherine_acquisition_t *acq);


### PR DESCRIPTION
This PR implements the possibility to switch off decoding of data and provide direct access to the raw `MD` received from Katherine.

The reason behind this is that when using `libkatherine` in any circumstance where data is not immediately consumed but rather stored, the current interface would force us to first decode the data and then re-serialize it in one or another form.

This PR adds the possibility adding a new data handler which reads directly from the `md_buffer`. The selection between decoded data and raw data is done through a switch to `katherine_acquisition_begin()`, namely `bool decode_data`.

One issue I had to work around is that the `katherine_acquisition_read()` method only returns when a status change beaks the loop. This status change is initiated by the frame-end handler if the correct amount of frames has been received. I had to sidestep this for the no-decoding runs, where now an additional check on `acq->aborted` is placed - and `katherine_acquisition_abort()` now sets `aborted = true`.

I am wondering about this value anyway, since it is set when receiving a `0xE` packet from Timepix3 but never actually read - and also the read loop continues even if the measurement has been aborted.