### PR TITLE
Install pkg-config file and fix examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,15 @@ project(katherine VERSION 0.1 LANGUAGES C CXX)
 
 option(BUILD_CXX        "build C++ binaries"        ON)
 option(BUILD_PYTHON     "build Python 3 bindings"   OFF)
-option(BUILD_EXAMPLES   "build example programs"    ON)
+option(BUILD_EXAMPLES   "build example programs"    OFF)
 
 set(CMAKE_C_STANDARD    17)
 set(CMAKE_CXX_STANDARD  17)
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+include(GNUInstallDirs)
 
 add_subdirectory(c)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(katherine VERSION 0.1 LANGUAGES C CXX)
 
 option(BUILD_CXX        "build C++ binaries"        ON)
 option(BUILD_PYTHON     "build Python 3 bindings"   OFF)
-option(BUILD_EXAMPLES   "build example programs"    OFF)
+option(BUILD_EXAMPLES   "build example programs"    ON)
 
 set(CMAKE_C_STANDARD    17)
 set(CMAKE_CXX_STANDARD  17)

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -29,28 +29,17 @@ set(KATHERINE_HEADERS
 add_library(katherine SHARED ${KATHERINE_SOURCES} ${KATHERINE_HEADERS})
 target_include_directories(katherine
     PUBLIC
-        $<INSTALL_INTERFACE:include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-file(GLOB headers "include/katherinexx/*")
-target_sources(
-  katherine
-  PUBLIC
-    FILE_SET public_headers
-    TYPE HEADERS
-    BASE_DIRS include
-    FILES ${KATHERINE_HEADERS}
-)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/katherine.pc.in katherine.pc @ONLY)
 
-INSTALL(TARGETS
-  katherine
-  FILE_SET public_headers
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS katherine LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES ${KATHERINE_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/katherine)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/katherine.pc DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)
 
 if(BUILD_EXAMPLES)
     add_subdirectory(examples)

--- a/c/examples/krun.c
+++ b/c/examples/krun.c
@@ -81,7 +81,7 @@ frame_ended(void *user_ctx, int frame_idx, bool completed, const katherine_frame
     const double recv_perc = 100. * info->received_pixels / info->sent_pixels;
 
     printf("\n");
-    printf("Ended frame %d.\n", frame_idx);    
+    printf("Ended frame %d.\n", frame_idx);
     printf(" - tpx3->katherine lost %lu pixels\n", info->lost_pixels);
     printf(" - katherine->pc sent %lu pixels\n", info->sent_pixels);
     printf(" - katherine->pc received %lu pixels\n", info->received_pixels);
@@ -132,7 +132,7 @@ run_acquisition(katherine_device_t *dev, const katherine_config_t *c)
     acq.handlers.frame_ended = frame_ended;
     acq.handlers.pixels_received = pixels_received;
 
-    res = katherine_acquisition_begin(&acq, c, READOUT_DATA_DRIVEN, ACQUISITION_MODE_TOA_TOT, true);
+    res = katherine_acquisition_begin(&acq, c, READOUT_DATA_DRIVEN, ACQUISITION_MODE_TOA_TOT, true, true);
     if (res != 0) {
         printf("Cannot begin acquisition.\n");
         printf("Reason: %s\n", strerror(res));
@@ -178,7 +178,7 @@ main(int argc, char *argv[])
         printf("Reason: %s\n", strerror(res));
         exit(6);
     }
-    
+
     print_chip_id(&device);
     run_acquisition(&device, &c);
 

--- a/c/katherine.pc.in
+++ b/c/katherine.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: katherine
+Description: Control library for the Katherine DAQ system
+Version: @PROJECT_VERSION@
+
+Requires:
+Libs: -L${libdir} -lkatherine
+Cflags: -I${includedir}

--- a/cxx/CMakeLists.txt
+++ b/cxx/CMakeLists.txt
@@ -1,27 +1,24 @@
-add_library(katherinexx INTERFACE)
-target_link_libraries(katherinexx INTERFACE katherine)
-
-TARGET_INCLUDE_DIRECTORIES(katherinexx INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-
-file(GLOB headers "include/katherinexx/*")
-target_sources(
-  katherinexx
-  PUBLIC
-    FILE_SET public_headers
-    TYPE HEADERS
-    BASE_DIRS include
-    FILES ${headers}
+set(KATHERINEXX_HEADERS
+    "include/katherinexx/acquisition.hpp"
+    "include/katherinexx/config.hpp"
+    "include/katherinexx/device.hpp"
+    "include/katherinexx/error.hpp"
+    "include/katherinexx/katherinexx.hpp"
+    "include/katherinexx/px_config.hpp"
 )
 
-INSTALL(TARGETS
-  katherinexx
-  FILE_SET public_headers
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+add_library(katherinexx INTERFACE)
+target_link_libraries(katherinexx INTERFACE katherine)
+target_include_directories(katherinexx
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/katherinexx.pc.in katherinexx.pc @ONLY)
+
+install(FILES ${KATHERINEXX_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/katherinexx)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/katherinexx.pc DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)
 
 if(BUILD_EXAMPLES)
     add_subdirectory(examples)

--- a/cxx/examples/krunxx.cpp
+++ b/cxx/examples/krunxx.cpp
@@ -88,7 +88,7 @@ void
 pixels_received(const mode::pixel_type *px, size_t count)
 {
     n_hits += count;
-    
+
     for (size_t i = 0; i < count; ++i) {
         std::cerr << (unsigned) px[i].coord.x << '\t'
                   << (unsigned) px[i].coord.y << '\t'
@@ -111,7 +111,7 @@ run_acquisition(katherine::device& dev, const katherine::config& c)
     using namespace std::chrono;
     using namespace std::literals::chrono_literals;
 
-    katherine::acquisition<mode> acq{dev, katherine::md_size * 34952533, sizeof(mode::pixel_type) * 65536, 500ms, 10s};
+    katherine::acquisition<mode> acq{dev, katherine::md_size * 34952533, sizeof(mode::pixel_type) * 65536, 500ms, 10s, true};
 
     acq.set_frame_started_handler(frame_started);
     acq.set_frame_ended_handler(frame_ended);

--- a/cxx/katherinexx.pc.in
+++ b/cxx/katherinexx.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: katherinexx
+Description: Control library for the Katherine DAQ system
+Version: @PROJECT_VERSION@
+
+Requires: katherine
+Cflags: -I${includedir}


### PR DESCRIPTION
This PR does two things:

1. It install a [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) files for `katherine` and `katherinexx` to allow it to be easier found by third party software
2. It fixes the compilation of the examples (broken in https://github.com/petrmanek/libkatherine/pull/3)

/cc @simonspa tested this with Constellation and works as expected