### PR TITLE
fix compilation under MinGW

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -35,6 +35,11 @@ target_include_directories(katherine
         ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
+# On Windows, link to ws2_32
+if(WIN32 OR MINGW)
+  target_link_libraries(katherine ws2_32)
+endif()
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/katherine.pc.in katherine.pc @ONLY)
 
 install(TARGETS katherine LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/c/include/katherine/udp.h
+++ b/c/include/katherine/udp.h
@@ -1,7 +1,7 @@
 /* Katherine Control Library
  *
  * This file was created on 29.5.18 by Petr Manek
- * 
+ *
  * Contents of this file are copyrighted and subject to license
  * conditions specified in the LICENSE file located in the top
  * directory.
@@ -26,25 +26,25 @@
 extern "C" {
 #endif
 
-int
+KATHERINE_EXPORTED int
 katherine_udp_init(katherine_udp_t *u, uint16_t local_port, const char *remote_addr, uint16_t remote_port, uint32_t timeout_ms);
 
-void
+KATHERINE_EXPORTED void
 katherine_udp_fini(katherine_udp_t *u);
 
-int
+KATHERINE_EXPORTED int
 katherine_udp_send_exact(katherine_udp_t* u, const void* data, size_t count);
 
-int
+KATHERINE_EXPORTED int
 katherine_udp_recv_exact(katherine_udp_t* u, void* data, size_t count);
 
-int
+KATHERINE_EXPORTED int
 katherine_udp_recv(katherine_udp_t* u, void* data, size_t* count);
 
-int
+KATHERINE_EXPORTED int
 katherine_udp_mutex_lock(katherine_udp_t *u);
 
-int
+KATHERINE_EXPORTED int
 katherine_udp_mutex_unlock(katherine_udp_t *u);
 
 #ifdef __cplusplus

--- a/c/include/katherine/udp_win.h
+++ b/c/include/katherine/udp_win.h
@@ -2,7 +2,7 @@
  *
  * This file was created on 31.8.18 by Felix Lehner.
  * This file was modified on 13.2.19 by Petr Manek.
- * 
+ *
  * Contents of this file are copyrighted and subject to license
  * conditions specified in the LICENSE file located in the top
  * directory.
@@ -19,9 +19,9 @@
 
 #ifdef KATHERINE_WIN
 
-#include <Windows.h>
+#include <winsock2.h>
+#include <windows.h>
 #include <stdint.h>
-#pragma comment(lib, "Ws2_32.lib")
 
 #ifdef __cplusplus
 extern "C" {

--- a/c/src/udp_win.c
+++ b/c/src/udp_win.c
@@ -2,7 +2,7 @@
  *
  * This file was created on 31.8.18 by Felix Lehner.
  * This file was modified on 13.2.19 by Petr Manek.
- * 
+ *
  * Contents of this file are copyrighted and subject to license
  * conditions specified in the LICENSE file located in the top
  * directory.
@@ -14,8 +14,8 @@ void empty_method() {}
 
 #ifdef KATHERINE_WIN
 
-#include <WinSock2.h>
-#include <WS2tcpip.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
 #include <katherine/udp.h>
 
 #ifdef KATHERINE_DEBUG_UDP


### PR DESCRIPTION
This allow libkatherine to be compiled with MinGW for Windows. In particular, this:

- Uses lower case for the header since under Unix they are case-sensitive
- Adds some missing `KATHERINE_EXPORTED` markers for the UDP functions
- Adds a missing header
- Remove an unsupported pragma
- Properly links via CMake