### PR TITLE
Fix TOA overflow after 107 sec

### DIFF
--- a/c/src/acquisition.c
+++ b/c/src/acquisition.c
@@ -37,7 +37,7 @@ handle_new_frame(katherine_acquisition_t *acq, const uint64_t *data)
 static inline void
 handle_timestamp_offset_driven_mode(katherine_acquisition_t *acq, const uint64_t *data)
 {
-    acq->last_toa_offset = 16384 * EXTRACT(*data, md_time_offset, offset);
+    acq->last_toa_offset = ((uint64_t) EXTRACT(*data, md_time_offset, offset) << 14);
 }
 
 static inline void


### PR DESCRIPTION
This fixes a major bug where the TOA timestamp would overflow after 32bit-signed. The cold code:

```c
acq->last_toa_offset = 16384 * EXTRACT(*data, md_time_offset, offset);
```

allocates a signed int, multiplies it with the 32b word read from the data packet, overflows it, and writes it to the 64b variable. This means only the lower 4 bytes of the word were ever used. The new code:

```c
acq->last_toa_offset = ((uint64_t) EXTRACT(*data, md_time_offset, offset) << 14);
```

Takes the 32b word from the data packet, casts it to 64bits and then bit-shifts it by the 14b from the Tpx3 timestamp.

It might be worth also correcting this in TrackLab:

```bash
$ git grep 16384
plugins/katherine/comm/dataparser.cpp:  m_lastToaOffsetCoarse = 16384 * static_cast<quint64>(offset);
```