### PR TITLE
Bugfix in reading acquisition data

### DIFF
--- a/c/src/acquisition.c
+++ b/c/src/acquisition.c
@@ -299,7 +299,7 @@ katherine_acquisition_fini(katherine_acquisition_t *acq)
 		if(!acq->decode_data && acq->aborted) {		\
 		  acq->state = ACQUISITION_SUCCEEDED;\
 		}				     \
-                \
+            continue;    \
             }\
             \
             last_data_received = time(NULL);\


### PR DESCRIPTION
Bug: Even if the program failed to receive data from the sensor (e.g. no hits yet -> timeout), it would try to read the entire length of buffer, and interpret it as data, resulting in unexpected behavior.

Fix: If we fail to read data from the sensor, do not try to read the buffer. Continue to trying receive again.